### PR TITLE
implement grunt watch in development

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,10 +9,10 @@ module.exports = function (grunt) {
     concat: {
       options: {
         stripBanners: true,
-        banner: '/* \n * <%= pkg.name %> - v<%= pkg.version %> - <%= grunt.template.today("yyyy") %> \n * \n * <%= pkg.author.name %>, <%= pkg.contributors[0].name %>, and the web community.\n * Licensed under the <%= pkg.license %> license. \n * \n * Many thanks to Brad Frost and Dave Olsen for inspiration, encouragement, and advice. \n *\n */\n\n',
+        banner: '/* \n * <%= pkg.name %> - v<%= pkg.version %> - <%= grunt.template.today("yyyy") %> \n * \n * This file is auto generated - please make changes to core/lib/patternlab-src.js \n * \n * <%= pkg.author.name %>, <%= pkg.contributors[0].name %>, and the web community.\n * Licensed under the <%= pkg.license %> license. \n * \n * Many thanks to Brad Frost and Dave Olsen for inspiration, encouragement, and advice. \n *\n */\n\n',
       },
       patternlab: {
-        src: './core/lib/patternlab.js',
+        src: './core/lib/patternlab-src.js',
         dest: './core/lib/patternlab.js'
       }
     },
@@ -24,6 +24,10 @@ module.exports = function (grunt) {
         configFile: './.eslintrc'
       },
       target: ['./core/lib/*']
+    },
+    watch: {
+      files: ['core/**/*', 'test/**/*', '!core/lib/patternlab.js'],
+      tasks: ['build']
     }
   });
 
@@ -31,6 +35,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  grunt.loadNpmTasks('grunt-contrib-watch');
 
   //travis CI task
   grunt.registerTask('travis', ['nodeunit', 'eslint']);

--- a/core/lib/patternlab-src.js
+++ b/core/lib/patternlab-src.js
@@ -1,15 +1,4 @@
-/* 
- * patternlab-node - v2.2.1 - 2016 
- * 
- * This file is auto generated - please make changes to core/lib/patternlab-src.js 
- * 
- * Brian Muenzenmeyer, Geoff Pursell, and the web community.
- * Licensed under the MIT license. 
- * 
- * Many thanks to Brad Frost and Dave Olsen for inspiration, encouragement, and advice. 
- *
- */
-
+/* This files is the src for patternlab */
 "use strict";
 
 var diveSync = require('diveSync'),
@@ -75,6 +64,7 @@ var patternlab_engine = function (config) {
     pe = require('./pattern_exporter'),
     lh = require('./lineage_hunter'),
     buildFrontEnd = require('./ui_builder'),
+    he = require('html-entities').AllHtmlEntities,
     plutils = require('./utilities'),
     sm = require('./starterkit_manager'),
     patternlab = {};
@@ -149,7 +139,7 @@ var patternlab_engine = function (config) {
     // references. This happens specifically with the Handlebars engine. Remove
     // if you like 180MB log files.
     function propertyStringReplacer(key, value) {
-      if (key === 'engine' && value && value.engineName) {
+      if (key === 'engine' && value.engineName) {
         return '{' + value.engineName + ' engine object}';
       }
       return value;
@@ -208,13 +198,13 @@ var patternlab_engine = function (config) {
       process.exit(1);
     }
     patternlab.patterns = [];
-    patternlab.subtypePatterns = {};
     patternlab.partials = {};
     patternlab.data.link = {};
 
     setCacheBust();
 
     var pattern_assembler = new pa(),
+      entity_encoder = new he(),
       pattern_exporter = new pe(),
       lineage_hunter = new lh(),
       patterns_dir = paths.source.patterns;
@@ -277,10 +267,6 @@ var patternlab_engine = function (config) {
     //render all patterns last, so lineageR works
     patternlab.patterns.forEach(function (pattern) {
 
-      if (!pattern.isPattern) {
-        return false;
-      }
-
       pattern.header = head;
 
       //todo move this into lineage_hunter
@@ -299,15 +285,15 @@ var patternlab_engine = function (config) {
         console.log(err);
       }
       allData = plutils.mergeData(allData, pattern.jsonFileData);
-      allData.cacheBuster = patternlab.cacheBuster;
 
+      //var headHTML = pattern_assembler.renderPattern(patternlab.userHead, allData);
       var headHTML = pattern_assembler.renderPattern(pattern.header, allData);
 
       //render the extendedTemplate with all data
       pattern.patternPartialCode = pattern_assembler.renderPattern(pattern, allData);
 
       //todo see if this is still needed
-      //pattern.patternPartialCodeE = entity_encoder.encode(pattern.patternPartialCode);
+      pattern.patternPartialCodeE = entity_encoder.encode(pattern.patternPartialCode);
 
       // stringify this data for individual pattern rendering and use on the styleguide
       // see if patternData really needs these other duped values
@@ -338,7 +324,7 @@ var patternlab_engine = function (config) {
 
       //set the pattern-specific footer by compiling the general-footer with data, and then adding it to the meta footer
       var footerPartial = pattern_assembler.renderPattern(patternlab.footer, {
-        isPattern: pattern.isPattern,
+        isPattern: true,
         patternData: pattern.patternData,
         cacheBuster: patternlab.cacheBuster
       });
@@ -356,8 +342,6 @@ var patternlab_engine = function (config) {
 
       //write the encoded version too
       fs.outputFileSync(paths.public.patterns + pattern.patternLink.replace('.html', '.markup-only.html'), pattern.patternPartialCode);
-
-      return true;
     });
 
     //export patterns if necessary

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "grunt": "~1.0.1",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-nodeunit": "^1.0.0",
-    "grunt-eslint": "^18.0.0"
+    "grunt-contrib-watch": "^1.0.0",
+    "grunt-eslint": "^18.0.0",
+    "readdir": "0.0.13"
   },
   "keywords": [
     "Pattern Lab",


### PR DESCRIPTION
## Proposal for development workflow

Addresses # There is no `grunt watch` when you want to run the `build` task on changes in development, as I'm fairly sure it's not there currently.

The main problem is that there is a header comment that gets injected into `core/lib/patternlab.js` which causes `watch` to go into an infinite loop.

I worked around this by introducing a `core/lib/patternlab-src.js` file as the source file and noting that `core/lib/patternlab.js` is now compiled and shouldn't be changed.

Summary of changes:
- don't watch core/lib/patternlab.js
- `{source: core/lib/patternlab-src.js, dest: core/lib/patternlab-src.js}` to get around concat causing an infinite loop
